### PR TITLE
Optimize the probability calculation for PHCs

### DIFF
--- a/dvm/dvm.py
+++ b/dvm/dvm.py
@@ -261,14 +261,12 @@ def hmc(n_iter, burn_frac, initial_phc, demo_per_prec, observed_per_prec,
         if verbose:
             print(f"[{cur_alg_step}/{alg_steps}] Creating the binomial coefficients...")
         cur_alg_step += 1
-        # Get the coefficients for the binomial calculations
-        coeff_dicts = pv.get_coefficients(demo_per_prec, observed_per_prec)
 
         # Apply `prob_votes` to every precinct
         def prob_log_prob_fn(phc):
             prob_list = []
             for prec, prec_votes in observed_per_prec.items():
-                prob_list.append(pv.prob_votes(phc, demo_per_prec[prec], prec_votes, coeff_dicts[prec]))
+                prob_list.append(pv.prob_votes(phc, demo_per_prec[prec], prec_votes))
 
             return tf.math.reduce_mean(prob_list)
 
@@ -423,15 +421,12 @@ def rwm(n_iter, burn_frac, initial_phc, demo_per_prec, observed_per_prec,
         if verbose:
             print(f"[{cur_alg_step}/{alg_steps}] Creating the binomial coefficients...")
         cur_alg_step += 1
-        # Get the coefficients for the binomial calculations,
-        # for each precinct
-        coeff_dicts = pv.get_coefficients(demo_per_prec, observed_per_prec)
 
         # Apply `prob_votes` to every precinct
         def prob_log_prob_fn(phc):
             prob_list = []
             for prec, prec_votes in observed_per_prec.items():
-                prob_list.append(pv.prob_votes(phc, demo_per_prec[prec], prec_votes, coeff_dicts[prec]))
+                prob_list.append(pv.prob_votes(phc, demo_per_prec[prec], prec_votes))
 
             return tf.math.reduce_mean(prob_list)
 

--- a/dvm/dvm_eval.py
+++ b/dvm/dvm_eval.py
@@ -16,6 +16,10 @@ import kings_ei as kei
 import phc
 import tools
 
+# Suppress logging for pyMC3
+pymc3_logger = logging.getLogger('pymc3')
+pymc3_logger.setLevel(logging.CRITICAL)
+
 
 def dvm_evaluator(election, label, candidate=None, phc_granularity=10,
                   hmc=False, expec_scoring=False, burn_frac=0.3,
@@ -37,7 +41,7 @@ def dvm_evaluator(election, label, candidate=None, phc_granularity=10,
     burn_frac (float): the fraction of MCMC iterations to burn
     n_steps (int): the number of steps to run the MCMC for
     n_iter (int): the number of times to repeat the experiment
-    verbose (bool): whether to display loogging and progress bars
+    verbose (bool): whether to display logging and progress bars
 
     return: a dictionary of the label, times and MSEs for
     the Discrete Voter Model
@@ -82,6 +86,7 @@ def dvm_evaluator(election, label, candidate=None, phc_granularity=10,
         best_cell_mle_phc = tools.get_most_probable_cell(mle_phc)
         best_cell_mean_phc = tools.get_most_probable_cell(mean_phc)
 
+        # Find the vote percentages the most probable cells calculate
         vote_pcts_mle_phc = elect.get_vote_pcts(best_cell_mle_phc, phc_granularity, election.dpp)
         vote_pcts_mean_phc = elect.get_vote_pcts(best_cell_mean_phc, phc_granularity, election.dpp)
 
@@ -139,11 +144,6 @@ def batch_dvm_eval(experiments, n_steps, n_iter, phc_granularity, hmc=True,
     df['n_steps'] = n_steps
 
     return df
-
-
-# Suppress logging for pyMC3
-pymc3_logger = logging.getLogger('pymc3')
-pymc3_logger.setLevel(logging.CRITICAL)
 
 
 def kei_evaluator(election, label, candidate=None, n_steps=500, n_iter=1,

--- a/dvm/elect.py
+++ b/dvm/elect.py
@@ -39,7 +39,20 @@ def get_vote_pcts_per_prec(index, matrix_dim, prec_demo):
     return: a dict of the vote percentages for each demographic
     group in a precinct
     """
-    return {group: (tf.cast(index[num], tf.float32) + 0.5) / matrix_dim for num, group in enumerate(prec_demo)}
+    return {group: (tf.cast(index[num], tf.float64) + 0.5) / matrix_dim for num, group in enumerate(prec_demo)}
+
+
+def get_vote_pcts2(index, matrix_dim):
+    """
+    Find the vote percentages for each demographic group,
+    given the index of an associated PHC.
+
+    index (int tuple): the index of the PHC
+    matrix_dim (int): the size of one dimension of the PHC
+
+    return: a list of the vote percentages for each demographic
+    """
+    return (tf.cast(index, tf.float32) + 0.5) / matrix_dim
 
 
 class Election:

--- a/dvm/elect.py
+++ b/dvm/elect.py
@@ -39,10 +39,10 @@ def get_vote_pcts_per_prec(index, matrix_dim, prec_demo):
     return: a dict of the vote percentages for each demographic
     group in a precinct
     """
-    return {group: (tf.cast(index[num], tf.float64) + 0.5) / matrix_dim for num, group in enumerate(prec_demo)}
+    return {group: (tf.cast(index[num], tf.float32) + 0.5) / matrix_dim for num, group in enumerate(prec_demo)}
 
 
-def get_vote_pcts2(index, matrix_dim):
+def get_vote_pcts_list(index, matrix_dim):
     """
     Find the vote percentages for each demographic group,
     given the index of an associated PHC.

--- a/dvm/prob_votes.py
+++ b/dvm/prob_votes.py
@@ -4,9 +4,6 @@ for ecological inference.
 """
 
 import functools
-import math
-import numpy as np
-import scipy.special
 import tensorflow as tf
 import tensorflow_probability as tfp
 
@@ -14,128 +11,8 @@ import elect
 import tools
 
 
-def get_coefficients(demo, observed):
-    """
-    Get the binomial coefficients for calculating the probability of a PHC
-    producing an election result.
-
-    demo (dict): the demographics of the district, per precinct
-    observed (dict): the number of votes a candidate got in each precinct
-
-    return: a Python dictionary containing the integer partitions and their
-    binomial coefficients for each precinct
-    """
-    coeff_dict = {}
-    observed_factorials = {prec_id: (obs_votes, math.factorial(obs_votes)) for prec_id, obs_votes in observed.items()}
-
-    for prec, (obs_votes, observed_factorial) in observed_factorials.items():
-        prec_coeff_dict = {}
-        for p in tools.permute_integer_partition(obs_votes, len(demo[prec])):
-            factorial_list = tf.convert_to_tensor(
-                scipy.special.factorial(p), dtype=float)
-            coefficient = observed_factorial / tf.math.reduce_prod(factorial_list)
-
-            prec_coeff_dict[p] = tf.cast(coefficient, tf.float32)
-        coeff_dict[prec] = prec_coeff_dict
-
-    return coeff_dict
-
-
-@tf.function
-def get_vote_probability(flat_index, phc, demo, coeff_dict):
-    """
-    Find the probability of a PHC's cell producing a
-    vote outcome of a given election for a candidate,
-    with a given PHC.
-
-    flat_index (int): the flat index of the selected cell
-    phc (Tensor): the Tensor representation of a PHC
-    demo (dict): the demographics of the district
-    coeff_dict (dict): the binomial coefficients for each partition
-
-    return: the probability that a PHC's cell produced the observed outcome
-    """
-    # Find the corresponding index
-    index = tf.unravel_index(flat_index, phc.shape)
-    matrix_dim = phc.shape[0]
-
-    # Find the vote percentages for each demographic group
-    vote_pcts = elect.get_vote_pcts_per_prec(index, matrix_dim, demo)
-
-    total_prob = [0] * len(coeff_dict)
-
-    # Go through the possible partitions of the vote outcome, by group
-    for index, (p, coeff) in enumerate(coeff_dict.items()):
-        # Assign the partitioned elements to groups
-        partition = dict(zip(demo.keys(), p))
-
-        # Find the probability of seeing that outcome
-        group_factors = [0.] * len(demo)
-
-        for num, group in enumerate(demo):
-            group_pct = vote_pcts[group]
-            candidate_group_num = partition[group]
-            total_group_num = demo[group]
-
-            # Check if this is feasible with the current demographic
-            # If infeasible, record the infeasibility and continue
-            if candidate_group_num > total_group_num:
-                break
-
-            group_factor_1 = tf.math.pow(group_pct, candidate_group_num)
-            group_factor_2 = tf.math.pow(1 - group_pct, total_group_num - candidate_group_num)
-            group_factors[num] = tf.math.multiply(group_factor_1, group_factor_2)
-
-        total_prob[index] = tf.math.multiply(tf.math.reduce_prod(group_factors), coeff)
-
-    return tf.math.reduce_sum(total_prob)
-
-
-@tf.function
-def prob_votes(phc, demo, observed, coeff_dict, rwm=False):
-    """
-    Find the probability that a PHC produced
-    the observed number of votes that a candidate
-    received in a given election, with a given
-    PHC.
-
-    phc (Tensor): the Tensor representation of a PHC
-    demo (dict): the demographics of the district
-    observed (int): the observed number of votes the candidate received
-    coeff_dict (dict): the binomial coefficients for each partition
-    rwm (bool): whether this function serves the RWM or HMC kernel
-
-    return: the probability that a PHC produced the observed outcomes
-    """
-    if rwm:
-        flat_phc = tf.reshape(phc, [-1])
-
-        get_vote_prob_partial = functools.partial(
-            get_vote_probability,
-            phc=phc,
-            demo=demo,
-            coeff_dict=coeff_dict)
-    else:
-        normalized_phc = tools.prob_normalize(phc)
-        flat_phc = tf.reshape(normalized_phc, [-1])
-
-        get_vote_prob_partial = functools.partial(
-            get_vote_probability,
-            phc=normalized_phc,
-            demo=demo,
-            coeff_dict=coeff_dict)
-
-    vote_prob = tf.map_fn(get_vote_prob_partial,
-        tf.range(tf.size(flat_phc)), dtype=tf.float32)
-
-    phc_prob_complement = tf.math.reduce_prod(
-        1 - tf.math.multiply(vote_prob, flat_phc))
-
-    return tf.math.log(1 - phc_prob_complement)
-
-
 @functools.lru_cache(maxsize=None)
-def get_vote_probability2(flat_index, phc_shape, demo, partitions):
+def get_vote_probability(flat_index, phc_shape, demo, partitions):
     """
     Find the probability of a PHC's cell producing a
     vote outcome of a given election for a candidate,
@@ -153,7 +30,7 @@ def get_vote_probability2(flat_index, phc_shape, demo, partitions):
     matrix_dim = phc_shape[0]
 
     # Find the vote percentages for each demographic group
-    vote_pcts = elect.get_vote_pcts2(index, matrix_dim)
+    vote_pcts = elect.get_vote_pcts_list(index, matrix_dim)
 
     # Binomial calculation
     # Independent binomial distributions for each demographic group where each
@@ -164,7 +41,7 @@ def get_vote_probability2(flat_index, phc_shape, demo, partitions):
     return tf.math.reduce_sum(tf.math.reduce_prod(pmf, 1))
 
 
-def prob_votes2(phc, demo, observed, rwm=False):
+def prob_votes(phc, demo, observed, rwm=False):
     """
     Find the probability that a PHC produced
     the observed number of votes that a candidate
@@ -184,7 +61,7 @@ def prob_votes2(phc, demo, observed, rwm=False):
         flat_phc = tf.reshape(phc, [-1])
 
         get_vote_prob_partial = functools.partial(
-            get_vote_probability2,
+            get_vote_probability,
             phc_shape=tuple(phc.shape),
             demo=tuple(demo.values()),
             partitions=partitions)
@@ -193,7 +70,7 @@ def prob_votes2(phc, demo, observed, rwm=False):
         flat_phc = tf.reshape(normalized_phc, [-1])
 
         get_vote_prob_partial = functools.partial(
-            get_vote_probability2,
+            get_vote_probability,
             phc_shape=tuple(normalized_phc.shape),
             demo=tuple(demo.values()),
             partitions=partitions)

--- a/dvm/prob_votes.py
+++ b/dvm/prob_votes.py
@@ -5,8 +5,10 @@ for ecological inference.
 
 import functools
 import math
+import numpy as np
 import scipy.special
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 import elect
 import tools
@@ -129,4 +131,90 @@ def prob_votes(phc, demo, observed, coeff_dict, rwm=False):
     phc_prob_complement = tf.math.reduce_prod(
         1 - tf.math.multiply(vote_prob, flat_phc))
 
+    return tf.math.log(1 - phc_prob_complement)
+
+
+@functools.lru_cache(maxsize=None)
+def get_vote_probability2(flat_index, phc_shape, demo, partitions):
+    """
+    Find the probability of a PHC's cell producing a
+    vote outcome of a given election for a candidate,
+    with a given PHC.
+
+    flat_index (int): the flat index of the selected cell
+    phc_shape (tuple): the shape of a PHC's Tensor representation
+    demo (tuple): the demographics of the district
+    partitions (tuple): the partitions of votes for a candidate
+
+    return: the probability that a PHC's cell produced the observed outcome
+    """
+    # Find the corresponding index
+    index = tf.unravel_index(flat_index, phc_shape)
+    matrix_dim = phc_shape[0]
+
+    # Find the vote percentages for each demographic group
+    vote_pcts = elect.get_vote_pcts2(index, matrix_dim)
+
+    # Binomial calculation
+    # Independent binomial distributions for each demographic group where each
+    # represents the probability of the voters in that group voting together
+    # to satisfy the possible partitions of voters
+    pmf = tfp.distributions.Binomial(demo, probs=vote_pcts).prob(partitions)
+
+    return tf.math.reduce_sum(tf.math.reduce_prod(pmf, 1))
+
+
+def prob_votes2(phc, demo, observed, rwm=False):
+    """
+    Find the probability that a PHC produced
+    the observed number of votes that a candidate
+    received in a given election, with a given
+    PHC.
+
+    phc (Tensor): the Tensor representation of a PHC
+    demo (dict): the demographics of the district
+    observed (int): the observed number of votes the candidate received
+    rwm (bool): whether this function serves the RWM or HMC kernel
+
+    return: the probability that a PHC produced the observed outcomes
+    """
+    partitions = tuple(tools.permute_integer_partition(observed, len(demo)))
+
+    if rwm:
+        flat_phc = tf.reshape(phc, [-1])
+
+        get_vote_prob_partial = functools.partial(
+            get_vote_probability2,
+            phc_shape=tuple(phc.shape),
+            demo=tuple(demo.values()),
+            partitions=partitions)
+    else:
+        normalized_phc = tools.prob_normalize(phc)
+        flat_phc = tf.reshape(normalized_phc, [-1])
+
+        get_vote_prob_partial = functools.partial(
+            get_vote_probability2,
+            phc_shape=tuple(normalized_phc.shape),
+            demo=tuple(demo.values()),
+            partitions=partitions)
+
+    # Calculate the probability for each cell
+    vote_prob = [get_vote_prob_partial(flat_index) for flat_index in range(tf.size(flat_phc))]
+
+    # TODO: Find a way to vectorize the above operation using Tensors
+    # vote_prob = tf.map_fn(get_vote_prob_partial,
+    #                       tf.range(tf.size(flat_phc)), dtype=tf.float32)
+
+    # tf.math.multiply(vote_prob, flat_phc): the vector of probabilities that
+    # each of the events happened (where an event is a cell producing the
+    # vote outcome).
+    # 1 - tf.math.multiply(vote_prob, flat_phc): the vector of probabilities
+    # that each of the events did not happen
+    # tf.math.reduce_prod(1 - tf.math.multiply(vote_prob, flat_phc)):
+    # the probability that none of the events happened
+    phc_prob_complement = tf.math.reduce_prod(
+        1 - tf.math.multiply(vote_prob, flat_phc))
+
+    # 1 - phc_prob_complement: the probability that at least one of the events
+    # happened
     return tf.math.log(1 - phc_prob_complement)


### PR DESCRIPTION
This pull request optimizes the probability calculation for PHCs in `prob_votes` by:

1. replacing the manual, lower-level calculation for the Binomial distribution with `tfp.distributions.Binomial`
2. memoizing the results of `get_vote_probability` with `functools.lru_cache`

This change causes significant performance improvements for the probability calculation, putting it on par with the expectation calculation of `expec_votes`.